### PR TITLE
fix: gh-pages可以上傳以點(.)開頭的檔案/避免 GitHub Pages 忽略底線檔/調整test.js圖片引用

### DIFF
--- a/js/test.js
+++ b/js/test.js
@@ -34,6 +34,9 @@ const questionResult = {
   wrongCount: 0
 };
 
+import checkImg from '../assets/images/check.png';
+import wrongImg from '../assets/images/wrong.png';
+
 window.addEventListener("load", loadQuestion);
 
 function loadQuestion() {
@@ -117,19 +120,19 @@ function handleAnswer(selectBtn, question) {
         questionResult.correctCount++;
         btn.classList.remove("btn-primary-500");
         btn.classList.add("btn-success-300");
-        btn.innerHTML += `<img src="../assets/images/check.png" alt="check" class="yes align-bottom ms-2">`;
+        btn.innerHTML += `<img src="${checkImg}" alt="check" class="yes align-bottom ms-2">`;
       } else {
         // 選錯
         questionResult.wrongCount++;
         btn.classList.remove("btn-primary-500");
         btn.classList.add("btn-danger-300");
-        btn.innerHTML += `<img src="../assets/images/wrong.png" alt="wrong" class="no align-bottom ms-2">`;
+        btn.innerHTML += `<img src="${wrongImg}" alt="wrong" class="no align-bottom ms-2">`;
       }
     } else if (option.correct) {
       // 顯示正確答案
       btn.classList.remove("btn-primary-500");
       btn.classList.add("btn-success-300");
-      btn.innerHTML += `<img src="../assets/images/check.png" alt="check" class="yes align-bottom ms-2">`;
+      btn.innerHTML += `<img src="${checkImg}" alt="check" class="yes align-bottom ms-2">`;
     }
     else {
       btn.disabled = true;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "vite build && gh-pages -d dist"
+    "deploy": "vite build && gh-pages -d dist --dotfiles"
   },
   "devDependencies": {
     "ejs": "^3.1.9",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { ViteEjsPlugin } from 'vite-plugin-ejs';
 import { fileURLToPath } from 'node:url';
+import fs from 'fs';
 import path from 'node:path';
 import { glob } from 'glob';
 
@@ -30,6 +31,14 @@ export default defineConfig({
     liveReload(['./layout/**/*.ejs', './pages/**/*.ejs', './pages/**/*.html']),
     ViteEjsPlugin(),
     moveOutputPlugin(),
+    {
+      name: 'add-nojekyll',
+      closeBundle() {
+        const file = path.resolve(__dirname, 'dist/.nojekyll');
+        fs.writeFileSync(file, '');
+        console.log('✅ 已建立 .nojekyll，避免 GitHub Pages 忽略底線檔案');
+      }
+    }
   ],
   server: {
     // 啟動 server 時預設開啟的頁面


### PR DESCRIPTION
### 調整
- test.js: 調整圖片引用方式
- vite.config.js: build 的時候，會自動建立 .nojekyll，讓 GitHub Pages 不要過濾有底線的檔案 (因為 Vite 打包有產生含底線的檔案)
- package.json: 讓 gh-pages 可以上傳以點(.)開頭的檔案